### PR TITLE
Set context to switch state instead of logical NOT.

### DIFF
--- a/zoomwayland@polyte.de/extension.js
+++ b/zoomwayland@polyte.de/extension.js
@@ -41,7 +41,7 @@ class Indicator extends PanelMenu.Button {
 
         let switchItem = new PopupMenu.PopupSwitchMenuItem(_('Enable Zoom Screensharing'), false);
         switchItem.connect('toggled', () => {
-          global.context.unsafe_mode = !global.context.unsafe_mode
+          global.context.unsafe_mode = switchItem.state
         });
 
         this.menu.addMenuItem(switchItem);


### PR DESCRIPTION
This is based on a comment I left in [your answer](https://askubuntu.com/a/1409298/877952) on askubuntu. Changes the switch to set the value of `global.context.unsafe_mode` based on the switch's value rather than logical NOTing it.