### PR TITLE
Update to support gnome 45+

### DIFF
--- a/zoomwayland@polyte.de/extension.js
+++ b/zoomwayland@polyte.de/extension.js
@@ -18,54 +18,51 @@
 
 /* exported init */
 
-const GETTEXT_DOMAIN = 'zoom-wayland-extension';
+import GObject from "gi://GObject";
+import St from "gi://St";
 
-const { GObject, St, Shell } = imports.gi;
+import {
+  Extension,
+  gettext as _,
+} from "resource:///org/gnome/shell/extensions/extension.js";
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Main = imports.ui.main;
-const PanelMenu = imports.ui.panelMenu;
-const PopupMenu = imports.ui.popupMenu;
-
-const _ = ExtensionUtils.gettext;
+import * as Main from "resource:///org/gnome/shell/ui/main.js";
+import * as PanelMenu from "resource:///org/gnome/shell/ui/panelMenu.js";
+import * as PopupMenu from "resource:///org/gnome/shell/ui/popupMenu.js";
 
 const Indicator = GObject.registerClass(
-class Indicator extends PanelMenu.Button {
+  class Indicator extends PanelMenu.Button {
     _init() {
-        super._init(0.0, _('Zoom Wayland Indicator'));
+      super._init(0.0, _("Zoom Wayland Indicator"));
 
-        this.add_child(new St.Icon({
-            icon_name: 'display-symbolic',
-            style_class: 'system-status-icon',
-        }));
+      this.add_child(
+        new St.Icon({
+          icon_name: "display-symbolic",
+          style_class: "system-status-icon",
+        })
+      );
 
-        let switchItem = new PopupMenu.PopupSwitchMenuItem(_('Enable Zoom Screensharing'), false);
-        switchItem.connect('toggled', () => {
-          global.context.unsafe_mode = switchItem.state
-        });
+      let switchItem = new PopupMenu.PopupSwitchMenuItem(
+        _("Enable Zoom Screensharing"),
+        false
+      );
+      switchItem.connect("toggled", () => {
+        global.context.unsafe_mode = switchItem.state;
+      });
 
-        this.menu.addMenuItem(switchItem);
-
+      this.menu.addMenuItem(switchItem);
     }
-});
+  }
+);
 
-class Extension {
-    constructor(uuid) {
-        this._uuid = uuid;
-        ExtensionUtils.initTranslations(GETTEXT_DOMAIN);
-    }
+export default class ZoomWaylandExtension extends Extension {
+  enable() {
+    this._indicator = new Indicator();
+    Main.panel.addToStatusArea(this.uuid, this._indicator);
+  }
 
-    enable() {
-        this._indicator = new Indicator();
-        Main.panel.addToStatusArea(this._uuid, this._indicator);
-    }
-
-    disable() {
-        this._indicator.destroy();
-        this._indicator = null;
-    }
-}
-
-function init(meta) {
-    return new Extension(meta.uuid);
+  disable() {
+    this._indicator.destroy();
+    this._indicator = null;
+  }
 }

--- a/zoomwayland@polyte.de/metadata.json
+++ b/zoomwayland@polyte.de/metadata.json
@@ -2,9 +2,8 @@
   "name": "Zoom Wayland Extension",
   "description": "Enables Zoom Screensharing under Wayland",
   "uuid": "zoomwayland@polyte.de",
-  "shell-version": [
-    "42"
-  ],
+  "shell-version": ["45"],
   "version": 0.1,
-  "url": "https://github.com/julianpollmann/zoom-wayland-gnome-extension"
+  "url": "https://github.com/julianpollmann/zoom-wayland-gnome-extension",
+  "gettext-domain": "zoom-wayland-extension"
 }


### PR DESCRIPTION
This updates your extension to work with gnome 45+

Unfortunately, it's not possible to make code compatible with both gnome 45+ and < gnome 45 without using some kind of pre-processor (e.g., https://logological.org/gpp). But, this is such a simple and small extension I figured having a gnome-45+ branch would be fine. You can push a separate package up for gnome 45 without changing the gnome 42 one.

I'm running it locally in ubuntu 23.10, but figured it might be helpful for others if you had a gnome 45 compatible version up there.

Not sure if you want to put it into `main` if you want to continue to have support for < gnome 45, but figured you can change the PR to go to a separate branch if you want both. Or, alternatively, just have two directories.